### PR TITLE
See changelog - v 0.0.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,15 @@
+# v 0.0.4 - Menu Generator A
+- added generation code for the main_game.c scene:
+	- controlled by arrays in lib/menus/main_game.h
+	- code will automatically divide the available icons between the top and bottom
+	- a matching array in same file controls the destination scenes.
+- added metanimation for the baby state
+- hatching egg now drops to the baby life stage.
+ - The old demo mode is accessible through the bug-shaped icon (DEBUG).
+ - This involved adding some hacks to game_manager.c that need to be removed when the evolution function is implemented.
+- Refactored the game manager to make the egg stage's length more easily modified.
+ - Temporarily lowered this to the debugging value of 1 minute, which is the minimum non-zero value.
+- Updated the default date to today (2021-10-29).
+- Refactored several functions to use the printTextMedium_enhanced fuction, which supports directives for highlighting/cell inversion.
+- Adds a scene (buttonproofer.c) that simply displays a message indicating the button you hit worked. Used for testing. Should be removed prior to a major release.
+- improvements in commenting of code.

--- a/lib/menus/main_game.h
+++ b/lib/menus/main_game.h
@@ -1,0 +1,35 @@
+/*
+ * main_game.h
+ *
+ *  Created on: Oct. 26, 2021
+ *      Author: patches
+ */
+
+#ifndef LIB_MENUS_MAIN_GAME_H_
+#define LIB_MENUS_MAIN_GAME_H_
+
+#pragma PERSISTENT(MG_count_menu_icons)
+const int MG_count_menu_icons = 6;
+
+#pragma PERSISTENT(MG_menu_icons)
+const char MG_menu_icons[6] = {
+                               0x07,
+                               0x08,
+                               0x09,
+                               0x0A,
+                               0x0B,
+                               0x0C
+};
+
+#pragma PERSISTENT(MG_menu_scene_addresses)
+const int MG_menu_scene_addresses[6] = {
+                                      SCENEADDR_proof_text,
+                                      SCENEADDR_proof_text,
+                                      SCENEADDR_proof_text,
+                                      SCENEADDR_proof_text,
+                                      SCENEADDR_demo_mode,
+                                      SCENEADDR_calendar_menu
+};
+
+
+#endif /* LIB_MENUS_MAIN_GAME_H_ */


### PR DESCRIPTION
# v 0.0.4 - Menu Generator A
- added generation code for the main_game.c scene:
	- controlled by arrays in lib/menus/main_game.h
	- code will automatically divide the available icons between the top and bottom
	- a matching array in same file controls the destination scenes.
- added metanimation for the baby state
- hatching egg now drops to the baby life stage.
 - The old demo mode is accessible through the bug-shaped icon (DEBUG).
 - This involved adding some hacks to game_manager.c that need to be removed when the evolution function is implemented.
- Refactored the game manager to make the egg stage's length more easily modified.
 - Temporarily lowered this to the debugging value of 1 minute, which is the minimum non-zero value.
- Updated the default date to today (2021-10-29).
- Refactored several functions to use the printTextMedium_enhanced fuction, which supports directives for highlighting/cell inversion.
- Adds a scene (buttonproofer.c) that simply displays a message indicating the button you hit worked. Used for testing. Should be removed prior to a major release.
- improvements in commenting of code.