### PR TITLE
enable output from RNG to EXP_SPI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -146,3 +146,4 @@
 - Changed the audio interface code to use PWM audio output. This will result in richer audio options beginning with Hardware Revision D, at the cost of quieter audio output for the Revision C development hardware.
 - Implemented the ability for the pet to poop and for the player to clean it up. This both uses and has implications for the "health byte", which will compe into play later in the development process.
 - Default wall clock time is now 8 AM on the defaulted day rather than midnight.
+- Adds an ability to the RNG Debug (Entropy Check) debug menu item that causes the result on each frame to be sent out as a signal on the accessory SPI port (EXP_CS et. al.). This will ultimately mean that RNG Debug *cannot be used* with an accessory connected. It may be removed at a future date. This featuer has some limitations that are hard to contravene.

--- a/src/lib/display/display.c
+++ b/src/lib/display/display.c
@@ -66,6 +66,10 @@ void Init_SPI(void) {
 
     GPIO_setAsOutputPin(GPIO_PORT_P1,GPIO_PIN3);     // Set P1.3 as output pin for CS of LCD
     GPIO_setOutputLowOnPin(GPIO_PORT_P1,GPIO_PIN3);  // disable LCD Module
+
+    GPIO_setAsOutputPin(GPIO_PORT_P8,GPIO_PIN0);     // Set P8.0 as output pin for CS of EXP
+    GPIO_setOutputLowOnPin(GPIO_PORT_P8,GPIO_PIN0);  // disable LCD Module
+
          //Wait for devices to initialize.
     __delay_cycles(100);
 

--- a/src/lib/hwinit/accessory_spi.c
+++ b/src/lib/hwinit/accessory_spi.c
@@ -1,0 +1,21 @@
+//******************************************************************************
+//  PETI FOSS Virtual Pet - Accessory SPI Feature
+//
+//  Implements primitives and API used for the Accessory SPI Featureset.
+//
+//  Zac Adam-MacEwen (Arcana Labs)
+//  March 2024
+//******************************************************************************
+
+#include <msp430.h>
+#include "driverlib/MSP430FR5xx_6xx/driverlib.h"
+#include "lib/hwinit/accessory_spi.h"
+
+// A very simple function to handle sending a single byte somewhere.
+// Please don't build serious functionality based on this; it is likely
+// going to be replaced wth something much more serious and proper.
+void ACCESSORY_spiSendByte(char byte){
+    GPIO_toggleOutputOnPin(ACCESSORY_PIN_PORT, ACCESSORY_PIN_PIN);
+    EUSCI_B_SPI_transmitData(EUSCI_B1_BASE, byte);
+    GPIO_toggleOutputOnPin(ACCESSORY_PIN_PORT, ACCESSORY_PIN_PIN);
+}

--- a/src/lib/hwinit/accessory_spi.h
+++ b/src/lib/hwinit/accessory_spi.h
@@ -1,0 +1,18 @@
+/*
+ * accessory_spi.h
+ *
+ *  Created on: March 11, 2025
+ *      Author: patches
+ */
+
+ #ifndef LIB_HWINIT_ACCESSORY_SPI_H
+ #define LIB_HWINIT_ACCESSORY_SPI_H
+ 
+ 
+#define ACCESSORY_PIN_PORT GPIO_PORT_P8
+#define ACCESSORY_PIN_PIN GPIO_PIN0
+ 
+void ACCESSORY_spiSendByte(char byte);
+ 
+ #endif /* LIB_HWINIT_ACCESSORY_SPI_H */
+ 


### PR DESCRIPTION
- Adds a concept of an accessory_spi handler.
- Adds the use of the accessory_spi handler to the RNG debug mode.

This will be used to collect some very large number of SPI rolls to try and figure out if the RNG is "fair" or not. This will help us with tuning random events.