### PR TITLE
Add falls-asleep alert

### DIFF
--- a/src/lib/alerts/alerts.c
+++ b/src/lib/alerts/alerts.c
@@ -33,3 +33,11 @@ void ALERTS_wake_up_alert(void){
     AUDIO_pulse(AUDIO_SHORT_PULSE);
     DISPLAY_wakeLCD();
 }
+
+void ALERTS_fall_asleep_alert(void){
+    if (!BLINKENLIGHTS_ALERT_LED_HOT){
+        BLINKENLIGHTS_blinkAlertLED(BLINKENLIGHTS_RAPID_PULSES);
+    }
+    AUDIO_pulse(AUDIO_SHORT_PULSE);
+    DISPLAY_wakeLCD();
+}

--- a/src/lib/alerts/alerts.h
+++ b/src/lib/alerts/alerts.h
@@ -13,5 +13,6 @@
 
 void ALERTS_hunger_fun_alert(void);
 void ALERTS_wake_up_alert(void);
+void ALERTS_fall_asleep_alert(void);
 
 #endif /* LIB_ALERTS_ALERTS_H_ */

--- a/src/lib/game/game_manager.c
+++ b/src/lib/game/game_manager.c
@@ -195,12 +195,18 @@ void GAME_NEEDS_evaluateSleeping(unsigned int current_hour){
     if (special_case == 0){ // We are neither the egg nor the baby; general logic now applies.
         //If it's between bed-o-clock and the wake-up time, we should be sleeping!
         if (GAME_evaluateBoundedTime(curfew_hour, wake_hour, current_hour)){
+            if (StateMachine.ACT == GM_ACTIVITY_IDLE){  // We are *falling* asleep.
+                ALERTS_fall_asleep_alert();
+            }
             StateMachine.ACT = GM_ACTIVITY_SLEEPING;
             needs_evaluation = 0;
         }
     }
     else if ((special_case == 2) && (baby_nap_hour != 255)){ // Oh baby, you came and you gave me an edge-case...
         if ((current_hour >= baby_nap_hour)){
+            if (StateMachine.ACT == GM_ACTIVITY_IDLE){  // We are *falling* asleep.
+                ALERTS_fall_asleep_alert();
+            }
             StateMachine.ACT = GM_ACTIVITY_SLEEPING; // Babyeh is now asleep
             needs_evaluation = 0;
         }


### PR DESCRIPTION
Correcting a minor annoyance from the days of the sleep update; the functions that detect if a pet should be asleep and *assert* that it should be asleep now also detect when that is a status change. That is to say, they detect the pet is *falling* asleep.

When this happens a simplistic alert is raised.